### PR TITLE
Empty string for contextPath not working correctly with resource tag

### DIFF
--- a/grails-app/taglib/grails/lesscss/LessTagLib.groovy
+++ b/grails-app/taglib/grails/lesscss/LessTagLib.groovy
@@ -113,7 +113,11 @@ class LessTagLib {
         }
 
         StringBuilder path = new StringBuilder()
-        path << g.resource(plugin:plugin ?: null, contextPath: contextPath ?: '', dir: dir, file: name)
+        if(contextPath) {
+            path << g.resource(plugin:plugin ?: null, contextPath: contextPath ?: '', dir: dir, file: name)
+        } else {
+            path << g.resource(plugin:plugin ?: null, dir: dir, file: name)
+        }
         if (extension) {
             path << extension
         }


### PR DESCRIPTION
Howdy,

We're using Grails 1.4 and 2.0.  When using the stylesheet tag of the lesscss plugin we would receive a 404 error because the plugin was requesting my less files with an incorrect URL.

I tracked down the issue.  For some reason passing a contextPath of "" to the resource tag doesn't work as expected (see line 116 in the generateRelativePath() method of the LessTagLib).  I added an if statement on the contextPath so that it won't be passed as an argument to the resource tag call if it doesn't exist.  This fixes the URL when a contextPath isn't specified such that the generated URL refers to the default context path.

Thanks for putting this plugin together.  It works really well!
